### PR TITLE
updated README for building server

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Quick start
 2. Build the server:
 ```powershell
 cd <repo-root>
+mkdir openchamp-server
 go build -o openchamp-server ./...
 ```
 3. Run the server:


### PR DESCRIPTION
With the current build instructions the command 
```go build -o openchamp-server ./... ``` 
fails to build as the folder openchamp-server does not exist  